### PR TITLE
OSOE-1241: Update dependency shepherd.js to v15

### DIFF
--- a/Lombiq.Walkthroughs/ResourceManagementOptionsConfiguration.cs
+++ b/Lombiq.Walkthroughs/ResourceManagementOptionsConfiguration.cs
@@ -15,6 +15,8 @@ public partial class ResourceManagementOptionsConfiguration : IConfigureOptions<
 
     private static readonly ResourceManifest _manifest = new();
 
+    public const string ShepherModulePath = Shepherd + "js/shepherd.mjs";
+
     static ResourceManagementOptionsConfiguration()
     {
         _manifest.DefineResource("$" + nameof(FeatureIds.Area), FeatureIds.Area);
@@ -27,7 +29,7 @@ public partial class ResourceManagementOptionsConfiguration : IConfigureOptions<
         _manifest
             .DefineScript(ResourceNames.Shepherd)
             .SetAttribute("type", "module")
-            .SetUrl(Shepherd + "js/shepherd.mjs")
+            .SetUrl(ShepherModulePath)
             .SetVersion(LibManVersions.ShepherdJs);
 
         _manifest

--- a/Lombiq.Walkthroughs/ResourceManagementOptionsConfiguration.cs
+++ b/Lombiq.Walkthroughs/ResourceManagementOptionsConfiguration.cs
@@ -27,7 +27,7 @@ public partial class ResourceManagementOptionsConfiguration : IConfigureOptions<
         _manifest
             .DefineScript(ResourceNames.Shepherd)
             .SetAttribute("type", "module")
-            .SetUrl(Shepherd + "esm/shepherd.mjs")
+            .SetUrl(Shepherd + "js/shepherd.mjs")
             .SetVersion(LibManVersions.ShepherdJs);
 
         _manifest

--- a/Lombiq.Walkthroughs/ResourceManagementOptionsConfiguration.cs
+++ b/Lombiq.Walkthroughs/ResourceManagementOptionsConfiguration.cs
@@ -13,9 +13,9 @@ public partial class ResourceManagementOptionsConfiguration : IConfigureOptions<
     private const string Shepherd = Vendors + "shepherd.js/dist/";
     private const string Js = Module + "js/";
 
-    private static readonly ResourceManifest _manifest = new();
-
     public const string ShepherModulePath = Shepherd + "js/shepherd.mjs";
+
+    private static readonly ResourceManifest _manifest = new();
 
     static ResourceManagementOptionsConfiguration()
     {

--- a/Lombiq.Walkthroughs/Views/WalkthroughsMeta.cshtml
+++ b/Lombiq.Walkthroughs/Views/WalkthroughsMeta.cshtml
@@ -1,3 +1,5 @@
+@using Lombiq.Walkthroughs
+
 <div id="shepherd-module-path"
-     data-url="@Url.Content("~/Lombiq.Walkthroughs/vendors/shepherd.js/dist/esm/shepherd.mjs")"
+     data-url="@Url.Content(ResourceManagementOptionsConfiguration.ShepherModulePath)"
      hidden></div>

--- a/Lombiq.Walkthroughs/libman.json
+++ b/Lombiq.Walkthroughs/libman.json
@@ -4,7 +4,7 @@
   "defaultDestination": "wwwroot/vendors/[Name]",
   "libraries": [
     {
-      "library": "shepherd.js@14.5.1",
+      "library": "shepherd.js@15.0.0",
       "files": [ "dist/esm/shepherd.mjs", "dist/css/*.css" ]
     }
   ]

--- a/Lombiq.Walkthroughs/libman.json
+++ b/Lombiq.Walkthroughs/libman.json
@@ -5,7 +5,7 @@
   "libraries": [
     {
       "library": "shepherd.js@15.0.0",
-      "files": [ "dist/esm/shepherd.mjs", "dist/css/*.css" ]
+      "files": [ "dist/js/shepherd.mjs", "dist/css/*.css" ]
     }
   ]
 }

--- a/Lombiq.Walkthroughs/libman.json
+++ b/Lombiq.Walkthroughs/libman.json
@@ -4,7 +4,7 @@
   "defaultDestination": "wwwroot/vendors/[Name]",
   "libraries": [
     {
-      "library": "shepherd.js@15.0.0",
+      "library": "shepherd.js@15.2.1",
       "files": [ "dist/js/shepherd.mjs", "dist/css/*.css" ]
     }
   ]


### PR DESCRIPTION
[OSOE-1241](https://lombiq.atlassian.net/browse/OSOE-1241)
Includes the Renovate dependency update and compatibility fix for the new package file layout in libman.

[OSOE-1241]: https://lombiq.atlassian.net/browse/OSOE-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ